### PR TITLE
Fixed empty address issue at reward distribution

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -1421,7 +1421,7 @@ func (kc *Client) getRewardAndRatioInfo(ctx context.Context, block string, rewar
 	// kgfAddress or kirAddress can be same with rewardbase. So instead of set ratio, we should add its ratio to map.
 	rewardRatioMap[rewardbase] = rewardRatioMap[rewardbase].Add(rewardRatioMap[rewardbase], cnRatio)
 	rewardRatioMap[kgfAddress] = rewardRatioMap[kgfAddress].Add(rewardRatioMap[kgfAddress], kgfRatio)
-	rewardRatioMap[kirAddress] = rewardRatioMap[kgfAddress].Add(rewardRatioMap[kirAddress], kirRatio)
+	rewardRatioMap[kirAddress] = rewardRatioMap[kirAddress].Add(rewardRatioMap[kirAddress], kirRatio)
 
 	return rewardAddresses, rewardRatioMap, mintingAmount, nil
 }


### PR DESCRIPTION
This PR Fixes #37  's second problem.

When there is no address set to roles (KGF and KIR) that reward must be given to block proposer.

Most of logics of rosetta-klaytn assume that returned reward addresses contain three addresses for each role(`rewardbase`, `kgfAddress`, `kirAddress`).
And to do minimum code changes, I inserted empty string `""` at reward addresses if there is no address set to role.

e.g. If KIR address is not set, 
`[<rewardbase>, <kgfAddress>, ""]` will be returned as reward addresses and
rewardRatioMap will be returned like below.
```
<rewardbase>: 34 + 12 (= 46)
<kgfAddress>: 54
```

I tested this PR with
* run `check:data` for private klaytn local network. (I'm using same `genesis.json` with Jamie).