### PR TITLE
Minor patch for configuration package

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -67,7 +67,7 @@ func TestLoadConfiguration(t *testing.T) {
 				SkipAdmin:              false,
 			},
 		},
-		"all set (mainnet) + geth": {
+		"all set (mainnet) + ken": {
 			Mode:      string(Online),
 			Network:   Mainnet,
 			Port:      "1000",

--- a/klaytn/types.go
+++ b/klaytn/types.go
@@ -100,7 +100,7 @@ const (
 	TransferGasLimit = int64(21000) //nolint:gomnd
 
 	// KlaytnNodeArguments are the arguments to start a klaytn node instance.
-	KlaytnNodeArguments = `--config=/app/klaytn/kend.toml --gcmode=archive`
+	KlaytnNodeArguments = `--config=/app/klaytn/ken.toml --gcmode=archive`
 
 	// IncludeMempoolCoins does not apply to rosetta-klaytn as it is not UTXO-based.
 	IncludeMempoolCoins = false


### PR DESCRIPTION
Do some minor patch for configuration.
* geth -> ken
* kend.toml -> ken.toml

All unit tests of configuration package are passed.


FYI. I tested with `ken.toml` below and checked that node ran successfully.
```toml
[CN]
SyncMode = "full"
NetworkId = 11111

[Node]
DataDir = "/Users/denver/klaytn-local/data"
HTTPHost = "0.0.0.0"
HTTPPort = 8551
HTTPVirtualHosts = ["*"]
HTTPModules = ["klay", "eth", "debug", "admin", "txpool"]
IPCPath = "/Users/denver/klaytn-local/data/klay.ipc"

[Node.HTTPTimeouts]
ReadTimeout = 120000000000
WriteTimeout = 120000000000
IdleTimeout = 120000000000
```