### PR TITLE
Return default balance and nonce to return result

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -1624,9 +1624,13 @@ func (kc *Client) Balance(
 	if err := kc.c.CallContext(ctx, &accountInfo, "klay_getAccount", accountIdf.Address, blockQuery); err != nil {
 		return nil, err
 	}
-
-	balance := accountInfo.GetAccount().GetBalance().String()
-	nonce := accountInfo.GetAccount().GetNonce()
+	// To return default account information
+	balance := "0"
+	nonce := uint64(0)
+	if accountInfo.GetAccount() != nil {
+		balance = accountInfo.GetAccount().GetBalance().String()
+		nonce = accountInfo.GetAccount().GetNonce()
+	}
 
 	var blockInfo types.Header
 	if err := kc.c.CallContext(ctx, &blockInfo, blockQueryMethod, blockQuery, false); err != nil {


### PR DESCRIPTION
I added logic to check `klay_getAccount` is empty or not to return default account info which has 0 balance and 0 nonce.

I also tested with Postman and result was below
```
{
    "block_identifier": {
        "index": 89297094,
        "hash": "0x3c301ddd61be260772d3fa6717ecfceb903210759d9ca19c1e59643fb15e605d"
    },
    "balances": [
        {
            "value": "0",
            "currency": {
                "symbol": "KLAY",
                "decimals": 18
            }
        }
    ],
    "metadata": {
        "nonce": 0
    }
}
```