### PR TITLE
To field can be nil so we need to handle this situation

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -797,7 +797,12 @@ func traceOps(
 
 		// Checksum addresses
 		from := MustChecksum(trace.From.String())
-		to := MustChecksum(trace.To.String())
+		var to string
+		if trace.To != nil {
+			to = MustChecksum(trace.To.String())
+		} else {
+			to = "0x"
+		}
 
 		if shouldAdd {
 			idx := int64(len(ops) + startIndex)
@@ -840,7 +845,7 @@ func traceOps(
 		// Skip empty to addresses (this may not
 		// actually occur but leaving it as a
 		// sanity check)
-		if len(trace.To.String()) == 0 {
+		if (trace.To != nil) && len(trace.To.String()) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
When there was a failed CREATE opcode during CALL,
there is no to field in the output of tracer result for that call.

So in this case, we set it as "0x" to clarify there is no to field.

FYI.
`rosetta-ethereum` in this case handle that value as Zero address but I think this is not correct way.
Because it can be interpreted as "msg.sender tried to do something for ZeroAddress".
But actually there is no `to` field, so that interpretation is not correct.

After patch, it parses failed CREATE operation during CALL like below.
(I removed FEE related operations for readability.)
```json
{
                "transaction_identifier": {
                    "hash": "0xfd529346ad72d1553dc78d4fc52326d21977e78253d432e6b294ddc65c00d463"
                },
                "operations": [
                    {
                        "operation_identifier": {
                            "index": 4
                        },
                        "type": "CREATE",
                        "status": "FAILURE",
                        "account": {
                            "address": "0xD51a59A79dbeE635B70B2Ed5038ebbEd553cAFd8"
                        },
                        "metadata": {
                            "error": "internal failure"
                        }
                    },
                    {
                        "operation_identifier": {
                            "index": 5
                        },
                        "related_operations": [
                            {
                                "index": 4
                            }
                        ],
                        "type": "CREATE",
                        "status": "FAILURE",
                        "account": {
                            "address": "0x"
                        },
                        "metadata": {
                            "error": "internal failure"
                        }
                    }
                ],
                "metadata": {
                    "gas_limit": "0x249f0",
                    "gas_price": "0x5d21dba00",
                    "receipt": {
                        "contractAddress": null,
                        "gasUsed": "0x249f0",
                        "logs": [],
                        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                        "status": "0x0",
                        "transactionHash": "0xfd529346ad72d1553dc78d4fc52326d21977e78253d432e6b294ddc65c00d463"
                    },
                    "trace": {
                        "calls": [
                            {
                                "error": "internal failure",
                                "from": "0xd51a59a79dbee635b70b2ed5038ebbed553cafd8",
                                "gas": "0x14946",
                                "gasUsed": "0x14946",
                                "input": "0x6060604052341561000c57fe5b60405160208061026c83398101604052515b60008054600160a060020a031916600160a060020a0383161790555b505b6102218061004b6000396000f300606060405236156100495763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416636ea056a98114610052578063c0ee0b8a14610092575b6100505b5b565b005b341561005a57fe5b61007e73ffffffffffffffffffffffffffffffffffffffff60043516602435610104565b604080519115158252519081900360200190f35b341561009a57fe5b604080516020600460443581810135601f810184900484028501840190955284845261005094823573ffffffffffffffffffffffffffffffffffffffff169460248035956064949293919092019181908401838280828437509496506101ef95505050505050565b005b6000805460408051602090810184905281517f3c18d31800000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff878116600483015292519290931692633c18d318926024808301939282900301818787803b151561017b57fe5b6102c65a03f1151561018957fe5b5050506040518051905073ffffffffffffffffffffffffffffffffffffffff1660003660006040516020015260405180838380828437820191505092505050602060405180830381856102c65a03f415156101e057fe5b50506040515190505b92915050565b5b5050505600a165627a7a723058204cdd69fdcf3cf6cbee9677fe380fa5f044048aa9e060ec5619a21ca5a5bd4cd10029000000000000000000000000d51a59a79dbee635b70b2ed5038ebbed553cafd8",
                                "type": "CREATE",
                                "value": "0x0"
                            }
                        ],
                        "error": "invalid opcode 0xfe",
                        "from": "0x58fd358b768af580a9dcaddbc291ebb8040f9fdd",
                        "gas": "0x1cf48",
                        "gasUsed": "0x1cf48",
                        "input": "0xa9b1d507",
                        "time": "94.025µs",
                        "to": "0xd51a59a79dbee635b70b2ed5038ebbed553cafd8",
                        "type": "CALL",
                        "value": "0x0"
                    }
                }
            }
```