### PR TITLE
Fixed fee operation logic to use same with Klaytn

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -1086,14 +1086,14 @@ func feeOps(
 			refundFee := new(big.Int).Sub(userInputFee, proposerEarnedAmount)
 
 			// fee * ratio / 100
-			feePayerOGFee := new(big.Int).Div(new(big.Int).Mul(userInputFee, new(big.Int).SetUint64(uint64(ratio))), common.Big100)
-			senderOGFee := new(big.Int).Sub(userInputFee, feePayerOGFee)
+			feePayerFeeWithGas := new(big.Int).Div(new(big.Int).Mul(userInputFee, new(big.Int).SetUint64(uint64(ratio))), common.Big100)
+			senderFeeWithGas := new(big.Int).Sub(userInputFee, feePayerFeeWithGas)
 
 			feePayerRefund := new(big.Int).Div(new(big.Int).Mul(refundFee, new(big.Int).SetUint64(uint64(ratio))), common.Big100)
 			senderRefund := new(big.Int).Sub(refundFee, feePayerRefund)
 
-			feePayerAmount := new(big.Int).Sub(feePayerOGFee, feePayerRefund)
-			senderAmount := new(big.Int).Sub(senderOGFee, senderRefund)
+			feePayerAmount := new(big.Int).Sub(feePayerFeeWithGas, feePayerRefund)
+			senderAmount := new(big.Int).Sub(senderFeeWithGas, senderRefund)
 
 			// Set sender tx fee payment and fee payer tx fee payment.
 			opsForFDR := []*RosettaTypes.Operation{
@@ -1110,7 +1110,7 @@ func feeOps(
 			if tx.FeeBurned != nil {
 				feePayerBurnAmount := new(
 					big.Int,
-				).Div(new(big.Int).Mul(tx.FeeBurned, feePayerRatio), big.NewInt(100))  // nolint: gomnd
+				).Div(new(big.Int).Mul(tx.FeeBurned, feePayerRatio), big.NewInt(100)) // nolint: gomnd
 				senderBurnAmount := new(big.Int).Sub(tx.FeeBurned, feePayerBurnAmount) // nolint: gomnd
 				burntOps := []*RosettaTypes.Operation{
 					createSuccessFeeOperation(


### PR DESCRIPTION
I made personal local network to check fee calculation logic.
So i used `25123456789` as a `unitprice` to make calculation harder in genesis.json file.
And then i made various transactions.

Actually during `check:data`, there was an error.
The cause of the error is the residual value when it is PartialFeeDelegation.

In Klaytn, when processing a transaction, the refundGas function returns the remainder to each fee payer and sender after calculating using the gas entered by the user, excluding the used gas.

When calculating the fee of the PartialFeeDelegation transaction, it may differ from the result in Klaytn if it is calculated using only the gasUsed of the transaction receipt.
Therefore, using the gas and gasUsed values, calculate refundGas and use it to modify it so that it can derive the same result as Klaytn.

You can try to calculate simple example with below
```
// Fee(using user input gas field value) 15347 
// Ratio 30
// Refund 1533 
// GasUsed 13814

// Calculate with Fee and Refund
FeePayer = 20000 - (15347 * 0.3) + (1533 * 0.3) = 15855
Sender = 20000 - (15347 - ((15347 * 0.3))) + (1533 - (1533 * 0.3)) = 10331

// Calculate with GasUsed only
FeePayer = 20000 - (13814 * 0.3) = 15856
Sender = 20000 - (13814 - (13814 * 0.3)) = 10330
```

**But we need to care about gas burning logic soon ([related issue](https://github.com/klaytn/rosetta-klaytn/issues/15))**

related to https://github.com/klaytn/rosetta-klaytn/issues/34