### PR TITLE
Handle nil trace.From when SELFDESTRUCT operation fails.

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -797,8 +797,12 @@ func traceOps(
 		}
 
 		// Checksum addresses
-		from := MustChecksum(trace.From.String())
-		var to string
+		var from, to string
+		if trace.From != nil {
+			from = MustChecksum(trace.From.String())
+		} else {
+			from = "0x"
+		}
 		if trace.To != nil {
 			to = MustChecksum(trace.To.String())
 		} else {


### PR DESCRIPTION
When SELFDESTRUCT operation fail, there is no from field.
So we need to handle this situation.

This problem is occurred during parsing https://baobab.scope.klaytn.com/tx/0xd4779a7cb5bfd3afb37573fd17b5680cef9b92fc44117560c80a77e0032fa37b?tabId=internalTx.