### PR TITLE
Improve performance when get block api

### DIFF
--- a/klaytn/client_test.go
+++ b/klaytn/client_test.go
@@ -2241,7 +2241,7 @@ func TestBlock_363415(t *testing.T) {
 			err = json.Unmarshal(file, r)
 			assert.NoError(t, err)
 		},
-	).Twice()
+	)
 
 	mockJSONRPC.On(
 		"CallContext",
@@ -2409,7 +2409,7 @@ func TestBlock_363753(t *testing.T) {
 			err = json.Unmarshal(file, r)
 			assert.NoError(t, err)
 		},
-	).Twice()
+	)
 
 	mockJSONRPC.On(
 		"CallContext",
@@ -2673,7 +2673,7 @@ func TestBlock_468179(t *testing.T) {
 			err = json.Unmarshal(file, r)
 			assert.NoError(t, err)
 		},
-	).Twice()
+	)
 
 	mockJSONRPC.On(
 		"CallContext",
@@ -2842,7 +2842,7 @@ func TestBlock_363366(t *testing.T) {
 			err = json.Unmarshal(file, r)
 			assert.NoError(t, err)
 		},
-	).Times(3)
+	)
 
 	mockJSONRPC.On(
 		"CallContext",
@@ -3107,7 +3107,7 @@ func TestBlock_468194(t *testing.T) {
 			err = json.Unmarshal(file, r)
 			assert.NoError(t, err)
 		},
-	).Twice()
+	)
 
 	mockJSONRPC.On(
 		"CallContext",


### PR DESCRIPTION
I tried to improve performance when parsing the block in rosetta-klaytn.

And during that process, i found that related with baseFee logic was kinda not working well.
I should figure out more detail why this didn't work, but before calling calculateGas function get baseFee first and then send that as a parameter helps to improve.

This branch is on https://github.com/klaytn/rosetta-klaytn/pull/86, so you can see [this commit](https://github.com/klaytn/rosetta-klaytn/commit/ddd19ed78e927489293b6ee3b5da9878237e25fa) separately what i did in this PR.