### PR TITLE
Added additional KEN arguments

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -86,7 +86,7 @@ const (
 	SkipAdminEnv = "SKIP_ADMIN"
 
 	// MiddlewareVersion is the version of rosetta-klaytn.
-	MiddlewareVersion = "1.0.3"
+	MiddlewareVersion = "1.0.4"
 )
 
 // Configuration determines how

--- a/klaytn/ken.yaml
+++ b/klaytn/ken.yaml
@@ -1,5 +1,6 @@
 syncmode: full
 datadir: /data
+rpc: true
 rpcaddr: 0.0.0.0
 rpcport: 8551
 rpcvhosts: \*

--- a/klaytn/types.go
+++ b/klaytn/types.go
@@ -108,7 +108,7 @@ const (
 	TransferGasLimit = int64(21000) //nolint:gomnd
 
 	// KlaytnNodeArguments are the arguments to start a klaytn node instance.
-	KlaytnNodeArguments = `--conf=/app/klaytn/ken.yaml --gcmode=archive`
+	KlaytnNodeArguments = `--conf /app/klaytn/ken.yaml --gcmode archive --rpc --rpcapi debug,admin,txpool,klay,governance --rpcport 8551`
 
 	// IncludeMempoolCoins does not apply to rosetta-klaytn as it is not UTXO-based.
 	IncludeMempoolCoins = false

--- a/services/network_service_test.go
+++ b/services/network_service_test.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// rosetta-klaytn version
-	middlewareVersion = "1.0.3"
+	middlewareVersion = "1.0.4"
 
 	defaultNetworkOptions = &types.NetworkOptionsResponse{
 		Version: &types.Version{


### PR DESCRIPTION
For now, yaml file is not applied correctly when starting node.

During waiting Klaytn fixes this issue, i will add additional arguments to `KlaytnNodeArguments` to make non-remote mode rosetta-klaytn running work.

Also i updated version number to v1.0.4 to release this.