### PR TITLE
fix block hash error when basefee = 0

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -347,6 +347,10 @@ func (kc *Client) blockHeaderByNumber(ctx context.Context, number *big.Int) (*ty
 		return nil, klaytn.NotFound
 	}
 
+	if head != nil && head.BaseFee != nil && head.BaseFee.Cmp(common.Big0) == 0 {
+		head.BaseFee = nil
+	}
+
 	return head, err
 }
 
@@ -360,6 +364,10 @@ func (kc *Client) blockHeaderByHash(ctx context.Context, hash string) (*types.He
 	err := kc.c.CallContext(ctx, &head, "klay_getBlockByHash", hash, false)
 	if err == nil && head == nil {
 		return nil, klaytn.NotFound
+	}
+
+	if head != nil && head.BaseFee != nil && head.BaseFee.Cmp(common.Big0) == 0 {
+		head.BaseFee = nil
 	}
 
 	return head, err
@@ -397,6 +405,9 @@ func (kc *Client) getBlock(
 		return nil, nil, err
 	}
 
+	if head.BaseFee != nil && head.BaseFee.Cmp(common.Big0) == 0 {
+		head.BaseFee = nil
+	}
 	// Get all transaction receipts
 	receipts, err := kc.getBlockReceipts(ctx, head.Hash(), len(body.Transactions))
 	if err != nil {


### PR DESCRIPTION
Fixes # .
rosetta  api doesn't work on cypress (86,816,005~99,841,496)
after magma hardfork update, the RPC call fills the header of the blocks in the period with the Basefee value with 0, even though the field value is treated as nil when calculating the hash value of a block.

