### PR TITLE
fix governance API call

### DIFF
--- a/klaytn/client.go
+++ b/klaytn/client.go
@@ -1363,8 +1363,8 @@ func (kc *Client) populateTransactions(
 		return transactions, nil
 	}
 
-	// Call `governance_chainConfigAt to check KoreCompatibleBlock Number.
-	err = kc.c.CallContext(ctx, &chainConfig, "governance_chainConfigAt", toBlockNumArg(block.Number()))
+	// Call `governance_getChainConfig to check KoreCompatibleBlock Number.
+	err = kc.c.CallContext(ctx, &chainConfig, "governance_getChainConfig", toBlockNumArg(block.Number()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot get block(%d) chainConfig: %w", block.Number(), err)
 	}
@@ -1572,13 +1572,13 @@ func (kc *Client) getRewardAndRatioInfo(
 	rewardbase string,
 ) ([]string, map[string]*big.Int, *big.Int, error) { // nolint
 	govItems := make(map[string]interface{})
-	// Call `governance_itemsAt` to get reward ratio.
-	err := kc.c.CallContext(ctx, &govItems, "governance_itemsAt", block)
+	// Call `governance_getParams` to get reward ratio.
+	err := kc.c.CallContext(ctx, &govItems, "governance_getParams", block)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	// `governance_itemsAt` has a field `reward.ratio`
+	// `governance_getParams` has a field `reward.ratio`
 	// where the reward ratios of cn, kgf and kir are defined using the `/` delimiter.
 	ratio, found := govItems["reward.ratio"].(string)
 	if !found {
@@ -1614,7 +1614,7 @@ func (kc *Client) getRewardAndRatioInfo(
 		)
 	}
 
-	// In `governance_itemsAt`, there is a field `reward.mintingamount`
+	// In `governance_getParams`, there is a field `reward.mintingamount`
 	// which is the amount of Peb minted when a block is generated. (e.g., "9600000000000000000")
 	minted, found := govItems["reward.mintingamount"].(string)
 	if !found {
@@ -1768,39 +1768,39 @@ func (kc *Client) blockRewardTransaction(
 }
 
 /*
-  type for kip103 treasury-rebalance contract's memo
-  {
-    "retirees": [
-        {
-            "retired": "0x2bcf9d3e4a846015e7e3152a614c684de16f37c6",
-            "balance": 423137197918247524183438005
-        },
-        {
-            "retired": "0x716f89d9bc333286c79db4ebb05516897c8d208a",
-            "balance": 125112416844433105491822174
-        },
-        {
-            "retired": "0x571f50dFD1c92C46CD4CECC540e9214Ff5B3421e",
-            "balance": 100000000000000000000
-        }
-    ],
-    "newbies": [
-        {
-            "newbie": "0xaa8d19a5e17e9e1bA693f13aB0E079d274a7e51E",
-            "fundAllocated": 300000000000000000000000000
-        },
-        {
-            "newbie": "0x8B537f5BC7d176a94D7bF63BeFB81586EB3D1c0E",
-            "fundAllocated": 50000000000000000000000000
-        },
-        {
-            "newbie": "0x47E3DbB8c1602BdB0DAeeE89Ce59452c4746CA1C",
-            "fundAllocated": 70000000000000000000000000
-        }
-    ],
-    "burnt": 128249714762680629675260179,
-    "success": true
-}
+	  type for kip103 treasury-rebalance contract's memo
+	  {
+	    "retirees": [
+	        {
+	            "retired": "0x2bcf9d3e4a846015e7e3152a614c684de16f37c6",
+	            "balance": 423137197918247524183438005
+	        },
+	        {
+	            "retired": "0x716f89d9bc333286c79db4ebb05516897c8d208a",
+	            "balance": 125112416844433105491822174
+	        },
+	        {
+	            "retired": "0x571f50dFD1c92C46CD4CECC540e9214Ff5B3421e",
+	            "balance": 100000000000000000000
+	        }
+	    ],
+	    "newbies": [
+	        {
+	            "newbie": "0xaa8d19a5e17e9e1bA693f13aB0E079d274a7e51E",
+	            "fundAllocated": 300000000000000000000000000
+	        },
+	        {
+	            "newbie": "0x8B537f5BC7d176a94D7bF63BeFB81586EB3D1c0E",
+	            "fundAllocated": 50000000000000000000000000
+	        },
+	        {
+	            "newbie": "0x47E3DbB8c1602BdB0DAeeE89Ce59452c4746CA1C",
+	            "fundAllocated": 70000000000000000000000000
+	        }
+	    ],
+	    "burnt": 128249714762680629675260179,
+	    "success": true
+	}
 */
 type kip103Memo struct {
 	Retirees []struct {

--- a/klaytn/client_test.go
+++ b/klaytn/client_test.go
@@ -1268,7 +1268,7 @@ func TestBlock_Current(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1288,7 +1288,7 @@ func TestBlock_Current(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1395,7 +1395,7 @@ func TestBlock_Hash(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1416,7 +1416,7 @@ func TestBlock_Hash(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1527,7 +1527,7 @@ func TestBlock_Index(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1547,7 +1547,7 @@ func TestBlock_Index(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x2af0",
 	).Return(
 		nil,
@@ -1927,7 +1927,7 @@ func TestBlock_2500994(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x262982",
 	).Return(
 		nil,
@@ -1947,7 +1947,7 @@ func TestBlock_2500994(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x262982",
 	).Return(
 		nil,
@@ -2102,7 +2102,7 @@ func TestBlock_87561170(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x53813d2",
 	).Return(
 		nil,
@@ -2122,7 +2122,7 @@ func TestBlock_87561170(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x53813d2",
 	).Return(
 		nil,
@@ -2277,7 +2277,7 @@ func TestBlock_363415(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x58b97",
 	).Return(
 		nil,
@@ -2297,7 +2297,7 @@ func TestBlock_363415(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x58b97",
 	).Return(
 		nil,
@@ -2452,7 +2452,7 @@ func TestBlock_363753(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x58ce9",
 	).Return(
 		nil,
@@ -2472,7 +2472,7 @@ func TestBlock_363753(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x58ce9",
 	).Return(
 		nil,
@@ -2711,7 +2711,7 @@ func TestBlock_468179(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x724d3",
 	).Return(
 		nil,
@@ -2731,7 +2731,7 @@ func TestBlock_468179(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x724d3",
 	).Return(
 		nil,
@@ -2886,7 +2886,7 @@ func TestBlock_363366(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x58b66",
 	).Return(
 		nil,
@@ -2906,7 +2906,7 @@ func TestBlock_363366(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x58b66",
 	).Return(
 		nil,
@@ -3146,7 +3146,7 @@ func TestBlock_468194(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x724e2",
 	).Return(
 		nil,
@@ -3166,7 +3166,7 @@ func TestBlock_468194(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x724e2",
 	).Return(
 		nil,
@@ -3321,7 +3321,7 @@ func TestBlock_1078(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x436",
 	).Return(
 		nil,
@@ -3341,7 +3341,7 @@ func TestBlock_1078(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x436",
 	).Return(
 		nil,
@@ -3661,7 +3661,7 @@ func TestBlock_335049(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x51cc9",
 	).Return(
 		nil,
@@ -3681,7 +3681,7 @@ func TestBlock_335049(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x51cc9",
 	).Return(
 		nil,
@@ -3834,7 +3834,7 @@ func TestBlock_1665(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x681",
 	).Return(
 		nil,
@@ -3854,7 +3854,7 @@ func TestBlock_1665(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x681",
 	).Return(
 		nil,
@@ -3968,7 +3968,7 @@ func TestBlock_4219(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_chainConfigAt",
+		"governance_getChainConfig",
 		"0x107b",
 	).Return(
 		nil,
@@ -3988,7 +3988,7 @@ func TestBlock_4219(t *testing.T) {
 		"CallContext",
 		ctx,
 		mock.Anything,
-		"governance_itemsAt",
+		"governance_getParams",
 		"0x107b",
 	).Return(
 		nil,


### PR DESCRIPTION
Fixes on rosetta for Klaytn v1.11.0, which deprecated a few governance APIs
